### PR TITLE
feat: create debug wireframe setting

### DIFF
--- a/assets/debug/debugMenu/debugMenu.gd
+++ b/assets/debug/debugMenu/debugMenu.gd
@@ -8,4 +8,5 @@ func _ready() -> void:
 
 	addCategory("Debug Settings");
 	addOption(OptionType.CheckBox, "Colliders Visible", "colliders_visible");
+	addOption(OptionType.CheckBox, "Wireframe Rendering", "render_wireframe");
 	addButton("Save & Exit", func(): onMenuExit.emit());

--- a/assets/debug/debugSettings/debugSettings.gd
+++ b/assets/debug/debugSettings/debugSettings.gd
@@ -7,6 +7,7 @@ extends GameSaveableBase;
 ################################################################################
 
 var colliders_visible : bool = false;
+var render_wireframe : bool = false;
 
 ################################################################################
 
@@ -15,8 +16,14 @@ func getFileLocation() -> String:
 	
 func _ready():
 	loadSaveable();
+	
 	updateDebugCollisionHint();
 	bindValueChanged("colliders_visible", updateDebugCollisionHint);
+	
+	RenderingServer.set_debug_generate_wireframes(true)
+	updateWireframeView()
+	bindValueChanged("render_wireframe", updateWireframeView);
+	
 
 func updateDebugCollisionHint():
 	# Update visibility hint.
@@ -44,5 +51,11 @@ func updateDebugCollisionHint():
 		var children_count : int = node.get_child_count()
 		for child_index in range(0, children_count):
 			queueStack.push_back(node.get_child(child_index))
+
+func updateWireframeView():
+	if (render_wireframe):
+		get_viewport().debug_draw = Viewport.DEBUG_DRAW_WIREFRAME
+	else:
+		get_viewport().debug_draw = Viewport.DEBUG_DRAW_DISABLED
 
 ################################################################################


### PR DESCRIPTION
I know we already have the collision box viewer debug mode, but as we lean into 3D more it could be useful to be able to see our models and their interactions as wireframes. If not we can just throw away this PR.

Somewhat costly `RenderingServer.set_debug_generate_wireframes(true)` is only run within a debug build of the game.

 NOTE:
 `RenderingServer.set_debug_generate_wireframes(true)` generates the wireframe and must be called before meshes are loaded by Godot, otherwise it does not work.