### PR TITLE
fix: add CollectAudio to AudioEffect group

### DIFF
--- a/prefabs/level1.tscn
+++ b/prefabs/level1.tscn
@@ -461,7 +461,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -28, 9.09476, -145)
 [node name="Seed60" parent="Seeds" instance=ExtResource("5_3kluf")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 9.069, -170)
 
-[node name="CollectAudio" type="AudioStreamPlayer" parent="Seeds"]
+[node name="CollectAudio" type="AudioStreamPlayer" parent="Seeds" groups=["AudioEffect"]]
 stream = ExtResource("21_jbhi1")
 
 [node name="Chickkins" type="Node" parent="."]


### PR DESCRIPTION
Seed's sound effect `CollectAudio` was not affected by the effect volume slider as it was not in the `AudioEffect` group.